### PR TITLE
Fix renamed VSS parameter for Windows.Triage.Targets

### DIFF
--- a/config/spec.yaml
+++ b/config/spec.yaml
@@ -4,7 +4,7 @@ OS: Windows
 # The list of artifacts and their args.
 Artifacts:
  Windows.Triage.Targets:
-    VSSAnalysisAge: 3
+    VSS_MAX_AGE_DAYS: 3
     _KapeTriage: Y
     _SANS_Triage: Y
     _BasicCollection: Y


### PR DESCRIPTION
The `Windows.KapeFiles.Targets` artifact was recently moved to the [Velociraptor Triage Project](https://triage.velocidex.com/) and renamed to `Windows.Triage.Targets`. During that change the `VSSAnalysisAge` parameter was renamed to `VSS_MAX_AGE_DAYS`.

https://triage.velocidex.com/docs/windows.triage.targets/

The current` spec.yaml` references `VSSAnalysisAge`, so the default `0` value is used for `VSS_MAX_AGE_DAYS`. This results in Volume Shadow Copies not being considered during file collection.