### PR TITLE
Self-contained macOS triage collectors + build-pipeline hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,10 @@ jobs:
             exit 1
           fi
 
-          # Sort by parsed numeric version (not lexicographically) so v0.76.10
-          # outranks v0.76.5; must match build_collector.sh's host selection.
-          ASSET_NAME=$(echo "$RESPONSE" | jq -r '
-            [.assets[]
-             | select(.name | test("velociraptor-v[0-9.]+-linux-amd64$"))
-             | {name: .name,
-                ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-linux-amd64$").v | split(".") | map(tonumber))}]
-            | sort_by(.ver) | last | .name')
+          # Select the upstream version with the SAME helper build_collector.sh
+          # uses, so the (numeric, not lexicographic) selection lives in one place.
+          source ./lib/collector_common.sh
+          ASSET_NAME=$(select_velociraptor_asset "$RESPONSE" "linux-amd64" | jq -r '.name // empty')
           UPSTREAM_VERSION=$(echo "$ASSET_NAME" | sed -n 's/.*velociraptor-v\([0-9.]*\)-linux-amd64$/\1/p')
           if [ -z "$UPSTREAM_VERSION" ]; then
             UPSTREAM_VERSION=$(echo "$RESPONSE" | jq -r '.tag_name' | sed 's/^v//')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,14 @@ jobs:
             exit 1
           fi
 
-          ASSET_NAME=$(echo "$RESPONSE" | jq -r '[.assets[] | select(.name | test("velociraptor-.*-linux-amd64$")) | .name] | sort | last')
+          # Sort by parsed numeric version (not lexicographically) so v0.76.10
+          # outranks v0.76.5; must match build_collector.sh's host selection.
+          ASSET_NAME=$(echo "$RESPONSE" | jq -r '
+            [.assets[]
+             | select(.name | test("velociraptor-v[0-9.]+-linux-amd64$"))
+             | {name: .name,
+                ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-linux-amd64$").v | split(".") | map(tonumber))}]
+            | sort_by(.ver) | last | .name')
           UPSTREAM_VERSION=$(echo "$ASSET_NAME" | sed -n 's/.*velociraptor-v\([0-9.]*\)-linux-amd64$/\1/p')
           if [ -z "$UPSTREAM_VERSION" ]; then
             UPSTREAM_VERSION=$(echo "$RESPONSE" | jq -r '.tag_name' | sed 's/^v//')

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 # Claude AI configuration
 CLAUDE.md
+
+# Build artifacts: downloaded Velociraptor binaries, the build datastore, and the
+# generated server config (contains self-signed private keys — never commit).
+/velociraptor
+/velociraptor_darwin_amd64
+/velociraptor_darwin_arm64
+/server.config.yaml
+/server.config.yaml.tmp
+/datastore/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ CLAUDE.md
 /server.config.yaml
 /server.config.yaml.tmp
 /datastore/
+
+# macOS directory metadata
+.DS_Store

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -3,38 +3,11 @@ set -euo pipefail
 
 echo "Starting build_collector.sh..."
 
-# Function to fetch with retries
-fetch_with_retry() {
-  local url="$1"
-  local max_retries=3
-  local retry_delay=2
-  local attempt=1
-  
-  while [ $attempt -le $max_retries ]; do
-    if [ $attempt -gt 1 ]; then
-      echo "Fetching from GitHub API (attempt $attempt/$max_retries)..." >&2
-    fi
-    response=$(curl -s -L "$url" || true)
-    
-    # Check if we got valid JSON
-    if echo "$response" | jq -e . >/dev/null 2>&1; then
-      echo "$response"
-      return 0
-    fi
-    
-    if [ $attempt -lt $max_retries ]; then
-      echo "Request failed, retrying in ${retry_delay}s..." >&2
-      sleep $retry_delay
-      retry_delay=$((retry_delay * 2))  # Exponential backoff
-    fi
-    
-    attempt=$((attempt + 1))
-  done
-  
-  echo "Error: Failed to fetch valid JSON from GitHub API after $max_retries attempts" >&2
-  echo "Debug - Last response received: ${response:0:200}..." >&2
-  return 1
-}
+# Shared helpers: fetch/download retries, version-aware asset selection, and the
+# stub verification run after every collector build.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/collector_common.sh
+. "$SCRIPT_DIR/lib/collector_common.sh"
 
 # Fetch the latest Velociraptor release information from GitHub API
 response=$(fetch_with_retry "https://api.github.com/repos/Velocidex/velociraptor/releases/latest") || exit 1
@@ -45,16 +18,8 @@ if [ -z "$response" ]; then
   exit 1
 fi
 
-# Identify download URL and derive version from asset name. Sort by the PARSED
-# numeric version (not lexicographically) so v0.76.10 correctly outranks v0.76.5
-# — the "latest" release contains many patch versions as separate assets.
-asset_info=$(echo "$response" | jq -r '
-  [.assets[]
-   | select(.name | test("velociraptor-v[0-9.]+-linux-amd64$"))
-   | {name: .name,
-      url: .browser_download_url,
-      ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-linux-amd64$").v | split(".") | map(tonumber))}]
-  | sort_by(.ver) | last')
+# Identify the linux-amd64 build host binary (highest numeric version).
+asset_info=$(select_velociraptor_asset "$response" "linux-amd64")
 download_url=$(echo "$asset_info" | jq -r '.url')
 asset_name=$(echo "$asset_info" | jq -r '.name')
 
@@ -114,61 +79,6 @@ mkdir -p data
 
 echo "Downloading Velociraptor binary from: $download_url"
 
-# Download with retries
-download_with_retry() {
-  local url="$1"
-  local output="$2"
-  local max_retries=3
-  local retry_delay=2
-  local attempt=1
-  
-  while [ $attempt -le $max_retries ]; do
-    if [ $attempt -gt 1 ]; then
-      echo "Downloading binary (attempt $attempt/$max_retries)..." >&2
-    fi
-    if curl -L "$url" -o "$output" --fail --silent --show-error; then
-      echo "Download successful"
-      return 0
-    fi
-    
-    if [ $attempt -lt $max_retries ]; then
-      echo "Download failed, retrying in ${retry_delay}s..." >&2
-      rm -f "$output"  # Clean up partial download
-      sleep $retry_delay
-      retry_delay=$((retry_delay * 2))  # Exponential backoff
-    fi
-    
-    attempt=$((attempt + 1))
-  done
-  
-  echo "Error: Failed to download binary after $max_retries attempts" >&2
-  return 1
-}
-
-# Verify a built collector is a real self-contained binary, not the ~100KB
-# BYO-binary shell stub the offline-collector builder emits when an embedded
-# tool fails to resolve. Checks both size and that the file is a compiled
-# executable (PE/ELF/Mach-O) rather than a shell script / text. Applied to every
-# released collector, not just macOS — any spec can stub out the same way.
-verify_collector_not_stub() {
-  local f="$1"
-  local min_bytes=10000000
-  local size ftype
-  size=$(wc -c < "$f")
-  ftype=$(file -b "$f")
-  if [ "$size" -lt "$min_bytes" ]; then
-    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
-    exit 1
-  fi
-  case "$ftype" in
-    *"shell script"*|*"text"*)
-      echo "Error: $f is '$ftype' — expected a compiled executable, got a script/text (stub?)" >&2
-      exit 1
-      ;;
-  esac
-  echo "Verified self-contained collector: $f ($size bytes, $ftype)"
-}
-
 # Download Velociraptor binary and make it executable
 download_with_retry "$download_url" "./velociraptor" || exit 1
 chmod +x ./velociraptor
@@ -179,13 +89,11 @@ chmod +x ./velociraptor
 # tiny BYO-binary shell stub instead of a self-contained collector. We download
 # both darwin binaries here and register them per-arch before each macOS build.
 # Pin the darwin binaries to the EXACT version of the linux-amd64 build host
-# ($velociraptor_version). The "latest" release contains many patch versions, so
-# an exact name match (rather than a lexicographic sort_by(.name)|last) both
-# selects the right one and detects per-arch version skew: if Velocidex has not
-# yet published darwin assets for this version, the URL is empty and we fail loud
-# instead of embedding a mismatched binary into a version-bound collector.
-darwin_amd64_url=$(echo "$response" | jq -r --arg n "velociraptor-v${velociraptor_version}-darwin-amd64" '.assets[] | select(.name == $n) | .browser_download_url')
-darwin_arm64_url=$(echo "$response" | jq -r --arg n "velociraptor-v${velociraptor_version}-darwin-arm64" '.assets[] | select(.name == $n) | .browser_download_url')
+# ($velociraptor_version): an exact name match detects per-arch version skew — if
+# Velocidex has not yet published darwin assets for this version, the URL is empty
+# and we fail loud instead of embedding a mismatched, version-bound binary.
+darwin_amd64_url=$(asset_url_by_name "$response" "velociraptor-v${velociraptor_version}-darwin-amd64")
+darwin_arm64_url=$(asset_url_by_name "$response" "velociraptor-v${velociraptor_version}-darwin-arm64")
 if [ -z "$darwin_amd64_url" ] || [ "$darwin_amd64_url" == "null" ] || \
    [ -z "$darwin_arm64_url" ] || [ "$darwin_arm64_url" == "null" ]; then
   echo "Error: darwin-amd64/darwin-arm64 binaries for v${velociraptor_version} not found in the latest release." >&2

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -45,8 +45,16 @@ if [ -z "$response" ]; then
   exit 1
 fi
 
-# Identify download URL and derive version from asset name
-asset_info=$(echo "$response" | jq -r '[.assets[] | select(.name | test("velociraptor-.*-linux-amd64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last')
+# Identify download URL and derive version from asset name. Sort by the PARSED
+# numeric version (not lexicographically) so v0.76.10 correctly outranks v0.76.5
+# — the "latest" release contains many patch versions as separate assets.
+asset_info=$(echo "$response" | jq -r '
+  [.assets[]
+   | select(.name | test("velociraptor-v[0-9.]+-linux-amd64$"))
+   | {name: .name,
+      url: .browser_download_url,
+      ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-linux-amd64$").v | split(".") | map(tonumber))}]
+  | sort_by(.ver) | last')
 download_url=$(echo "$asset_info" | jq -r '.url')
 asset_name=$(echo "$asset_info" | jq -r '.name')
 
@@ -135,6 +143,30 @@ download_with_retry() {
   
   echo "Error: Failed to download binary after $max_retries attempts" >&2
   return 1
+}
+
+# Verify a built collector is a real self-contained binary, not the ~100KB
+# BYO-binary shell stub the offline-collector builder emits when an embedded
+# tool fails to resolve. Checks both size and that the file is a compiled
+# executable (PE/ELF/Mach-O) rather than a shell script / text. Applied to every
+# released collector, not just macOS — any spec can stub out the same way.
+verify_collector_not_stub() {
+  local f="$1"
+  local min_bytes=10000000
+  local size ftype
+  size=$(wc -c < "$f")
+  ftype=$(file -b "$f")
+  if [ "$size" -lt "$min_bytes" ]; then
+    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
+    exit 1
+  fi
+  case "$ftype" in
+    *"shell script"*|*"text"*)
+      echo "Error: $f is '$ftype' — expected a compiled executable, got a script/text (stub?)" >&2
+      exit 1
+      ;;
+  esac
+  echo "Verified self-contained collector: $f ($size bytes, $ftype)"
 }
 
 # Download Velociraptor binary and make it executable
@@ -318,14 +350,17 @@ fi
 # Build the x64 collector
 echo "Building Windows x64 collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector.exe
 
 # Build the x86 (32-bit) collector using the same datastore
 echo "Building Windows x86 collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec_x86.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_x86.exe
 
 # Build the Linux collector using the same datastore
 echo "Building Linux collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec_linux.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_Linux
 
 # The macOS collectors need the darwin velociraptor binary embedded. Both the
 # MacOS and MacOSArm specs resolve to the single "VelociraptorCollector" tool,
@@ -333,22 +368,6 @@ echo "Building Linux collector..."
 # before building each arch (re-pointing the tool between builds). "tools upload"
 # operates through a server config rather than --datastore, so generate a minimal
 # config whose datastore points at the same ./datastore the collector builds use.
-# A self-contained macOS collector embeds the ~60-70MB darwin binary. If the
-# tool registration silently fails (e.g. the config rewrite below didn't take or
-# the tool name changed upstream), the builder falls back to a ~100KB BYO-binary
-# shell stub. Fail the build rather than ship a stub (the original bug class).
-verify_collector_not_stub() {
-  local f="$1"
-  local min_bytes=10000000
-  local size
-  size=$(wc -c < "$f")
-  if [ "$size" -lt "$min_bytes" ]; then
-    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
-    exit 1
-  fi
-  echo "Verified self-contained collector: $f ($size bytes)"
-}
-
 echo "Generating server config for darwin tool registration..."
 ./velociraptor config generate > server.config.yaml
 DATASTORE_ABS="$(pwd)/datastore"

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -146,12 +146,18 @@ chmod +x ./velociraptor
 # has no default download URL, so without supplying the binary the build emits a
 # tiny BYO-binary shell stub instead of a self-contained collector. We download
 # both darwin binaries here and register them per-arch before each macOS build.
-# Match the same release the linux-amd64 binary came from (sort_by name | last).
-darwin_amd64_url=$(echo "$response" | jq -r '[.assets[] | select(.name | test("darwin-amd64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last | .url')
-darwin_arm64_url=$(echo "$response" | jq -r '[.assets[] | select(.name | test("darwin-arm64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last | .url')
+# Pin the darwin binaries to the EXACT version of the linux-amd64 build host
+# ($velociraptor_version). The "latest" release contains many patch versions, so
+# an exact name match (rather than a lexicographic sort_by(.name)|last) both
+# selects the right one and detects per-arch version skew: if Velocidex has not
+# yet published darwin assets for this version, the URL is empty and we fail loud
+# instead of embedding a mismatched binary into a version-bound collector.
+darwin_amd64_url=$(echo "$response" | jq -r --arg n "velociraptor-v${velociraptor_version}-darwin-amd64" '.assets[] | select(.name == $n) | .browser_download_url')
+darwin_arm64_url=$(echo "$response" | jq -r --arg n "velociraptor-v${velociraptor_version}-darwin-arm64" '.assets[] | select(.name == $n) | .browser_download_url')
 if [ -z "$darwin_amd64_url" ] || [ "$darwin_amd64_url" == "null" ] || \
    [ -z "$darwin_arm64_url" ] || [ "$darwin_arm64_url" == "null" ]; then
-  echo "Error: Could not find darwin-amd64/darwin-arm64 binaries in the latest release" >&2
+  echo "Error: darwin-amd64/darwin-arm64 binaries for v${velociraptor_version} not found in the latest release." >&2
+  echo "The build host is linux-amd64 v${velociraptor_version}; both darwin binaries must match it (per-arch version skew?)." >&2
   exit 1
 fi
 echo "Downloading Velociraptor darwin-amd64 binary..."
@@ -327,6 +333,22 @@ echo "Building Linux collector..."
 # before building each arch (re-pointing the tool between builds). "tools upload"
 # operates through a server config rather than --datastore, so generate a minimal
 # config whose datastore points at the same ./datastore the collector builds use.
+# A self-contained macOS collector embeds the ~60-70MB darwin binary. If the
+# tool registration silently fails (e.g. the config rewrite below didn't take or
+# the tool name changed upstream), the builder falls back to a ~100KB BYO-binary
+# shell stub. Fail the build rather than ship a stub (the original bug class).
+verify_collector_not_stub() {
+  local f="$1"
+  local min_bytes=10000000
+  local size
+  size=$(wc -c < "$f")
+  if [ "$size" -lt "$min_bytes" ]; then
+    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
+    exit 1
+  fi
+  echo "Verified self-contained collector: $f ($size bytes)"
+}
+
 echo "Generating server config for darwin tool registration..."
 ./velociraptor config generate > server.config.yaml
 DATASTORE_ABS="$(pwd)/datastore"
@@ -338,12 +360,22 @@ awk -v ds="$DATASTORE_ABS" '
   { print }
 ' server.config.yaml > server.config.yaml.tmp && mv server.config.yaml.tmp server.config.yaml
 
+# Confirm the rewrite actually pointed the datastore at ./datastore. If the
+# config format changes and the awk no-ops, "tools upload" would write the tool
+# to the default datastore and the collector build would silently emit a stub.
+if ! grep -qF "location: ${DATASTORE_ABS}" server.config.yaml; then
+  echo "Error: server.config.yaml Datastore was not repointed to ${DATASTORE_ABS} (velociraptor config format may have changed)" >&2
+  exit 1
+fi
+
 # Build the macOS ARM64 collector (embed darwin-arm64 binary)
 echo "Registering darwin-arm64 binary and building macOS ARM64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_arm64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos_arm.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS_ARM
 
 # Build the macOS x64 collector (re-point VelociraptorCollector to darwin-amd64)
 echo "Registering darwin-amd64 binary and building macOS x64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_amd64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -141,6 +141,24 @@ download_with_retry() {
 download_with_retry "$download_url" "./velociraptor" || exit 1
 chmod +x ./velociraptor
 
+# Download the macOS (darwin) binaries. The offline-collector builder maps both
+# the MacOS and MacOSArm targets to a single "VelociraptorCollector" tool that
+# has no default download URL, so without supplying the binary the build emits a
+# tiny BYO-binary shell stub instead of a self-contained collector. We download
+# both darwin binaries here and register them per-arch before each macOS build.
+# Match the same release the linux-amd64 binary came from (sort_by name | last).
+darwin_amd64_url=$(echo "$response" | jq -r '[.assets[] | select(.name | test("darwin-amd64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last | .url')
+darwin_arm64_url=$(echo "$response" | jq -r '[.assets[] | select(.name | test("darwin-arm64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last | .url')
+if [ -z "$darwin_amd64_url" ] || [ "$darwin_amd64_url" == "null" ] || \
+   [ -z "$darwin_arm64_url" ] || [ "$darwin_arm64_url" == "null" ]; then
+  echo "Error: Could not find darwin-amd64/darwin-arm64 binaries in the latest release" >&2
+  exit 1
+fi
+echo "Downloading Velociraptor darwin-amd64 binary..."
+download_with_retry "$darwin_amd64_url" "./velociraptor_darwin_amd64" || exit 1
+echo "Downloading Velociraptor darwin-arm64 binary..."
+download_with_retry "$darwin_arm64_url" "./velociraptor_darwin_arm64" || exit 1
+
 # Download and extract Windows.Triage.Targets artifact
 mkdir -p ./datastore/artifact_definitions/Windows/Triage
 ARTIFACT_URL="https://triage.velocidex.com/artifacts/Windows.Triage.Targets.zip"
@@ -303,10 +321,29 @@ echo "Building Windows x86 collector..."
 echo "Building Linux collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec_linux.yaml
 
-# Build the macOS x64 collector using the same datastore
-echo "Building macOS x64 collector..."
-./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml
+# The macOS collectors need the darwin velociraptor binary embedded. Both the
+# MacOS and MacOSArm specs resolve to the single "VelociraptorCollector" tool,
+# so we register the appropriate binary into the datastore inventory immediately
+# before building each arch (re-pointing the tool between builds). "tools upload"
+# operates through a server config rather than --datastore, so generate a minimal
+# config whose datastore points at the same ./datastore the collector builds use.
+echo "Generating server config for darwin tool registration..."
+./velociraptor config generate > server.config.yaml
+DATASTORE_ABS="$(pwd)/datastore"
+awk -v ds="$DATASTORE_ABS" '
+  /^Datastore:/ { in_ds = 1 }
+  in_ds && /^  location:/ { print "  location: " ds; next }
+  in_ds && /^  filestore_directory:/ { print "  filestore_directory: " ds; next }
+  /^[A-Za-z]/ && !/^Datastore:/ { in_ds = 0 }
+  { print }
+' server.config.yaml > server.config.yaml.tmp && mv server.config.yaml.tmp server.config.yaml
 
-# Build the macOS ARM64 collector using the same datastore
-echo "Building macOS ARM64 collector..."
+# Build the macOS ARM64 collector (embed darwin-arm64 binary)
+echo "Registering darwin-arm64 binary and building macOS ARM64 collector..."
+./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_arm64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos_arm.yaml
+
+# Build the macOS x64 collector (re-point VelociraptorCollector to darwin-amd64)
+echo "Registering darwin-amd64 binary and building macOS x64 collector..."
+./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_amd64
+./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -12,38 +12,11 @@ command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed
 
 echo "Starting build_collector.sh (macOS version)..."
 
-# Function to fetch with retries
-fetch_with_retry() {
-  local url="$1"
-  local max_retries=3
-  local retry_delay=2
-  local attempt=1
-
-  while [ $attempt -le $max_retries ]; do
-    if [ $attempt -gt 1 ]; then
-      echo "Fetching from GitHub API (attempt $attempt/$max_retries)..." >&2
-    fi
-    response=$(curl -s -L "$url" || true)
-
-    # Check if we got valid JSON
-    if echo "$response" | jq -e . >/dev/null 2>&1; then
-      echo "$response"
-      return 0
-    fi
-
-    if [ $attempt -lt $max_retries ]; then
-      echo "Request failed, retrying in ${retry_delay}s..." >&2
-      sleep $retry_delay
-      retry_delay=$((retry_delay * 2))  # Exponential backoff
-    fi
-
-    attempt=$((attempt + 1))
-  done
-
-  echo "Error: Failed to fetch valid JSON from GitHub API after $max_retries attempts" >&2
-  echo "Debug - Last response received: ${response:0:200}..." >&2
-  return 1
-}
+# Shared helpers: fetch/download retries, version-aware asset selection, and the
+# stub verification run after every collector build.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/collector_common.sh
+. "$SCRIPT_DIR/lib/collector_common.sh"
 
 # Fetch the latest Velociraptor release information from GitHub API
 response=$(fetch_with_retry "https://api.github.com/repos/Velocidex/velociraptor/releases/latest") || exit 1
@@ -54,14 +27,8 @@ if [ -z "$response" ]; then
   exit 1
 fi
 
-# Identify download URL and derive version from asset name
-asset_info=$(echo "$response" | jq -r '
-  [.assets[]
-   | select(.name | test("velociraptor-v[0-9.]+-darwin-amd64$"))
-   | {name: .name,
-      url: .browser_download_url,
-      ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-darwin-amd64$").v | split(".") | map(tonumber))}]
-  | sort_by(.ver) | last')
+# Identify the darwin-amd64 host binary (highest numeric version).
+asset_info=$(select_velociraptor_asset "$response" "darwin-amd64")
 download_url=$(echo "$asset_info" | jq -r '.url')
 asset_name=$(echo "$asset_info" | jq -r '.name')
 
@@ -109,61 +76,6 @@ mkdir -p data
 
 echo "Downloading Velociraptor binary from: $download_url"
 
-# Download with retries
-download_with_retry() {
-  local url="$1"
-  local output="$2"
-  local max_retries=3
-  local retry_delay=2
-  local attempt=1
-
-  while [ $attempt -le $max_retries ]; do
-    if [ $attempt -gt 1 ]; then
-      echo "Downloading binary (attempt $attempt/$max_retries)..." >&2
-    fi
-    if curl -L "$url" -o "$output" --fail --silent --show-error; then
-      echo "Download successful"
-      return 0
-    fi
-
-    if [ $attempt -lt $max_retries ]; then
-      echo "Download failed, retrying in ${retry_delay}s..." >&2
-      rm -f "$output"  # Clean up partial download
-      sleep $retry_delay
-      retry_delay=$((retry_delay * 2))  # Exponential backoff
-    fi
-
-    attempt=$((attempt + 1))
-  done
-
-  echo "Error: Failed to download binary after $max_retries attempts" >&2
-  return 1
-}
-
-# Verify a built collector is a real self-contained binary, not the ~100KB
-# BYO-binary shell stub the offline-collector builder emits when an embedded
-# tool fails to resolve. Checks both size and that the file is a compiled
-# executable (PE/ELF/Mach-O) rather than a shell script / text. Applied to every
-# released collector, not just macOS — any spec can stub out the same way.
-verify_collector_not_stub() {
-  local f="$1"
-  local min_bytes=10000000
-  local size ftype
-  size=$(wc -c < "$f")
-  ftype=$(file -b "$f")
-  if [ "$size" -lt "$min_bytes" ]; then
-    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
-    exit 1
-  fi
-  case "$ftype" in
-    *"shell script"*|*"text"*)
-      echo "Error: $f is '$ftype' — expected a compiled executable, got a script/text (stub?)" >&2
-      exit 1
-      ;;
-  esac
-  echo "Verified self-contained collector: $f ($size bytes, $ftype)"
-}
-
 # Download Velociraptor binary and make it executable (darwin-amd64 host binary)
 download_with_retry "$download_url" "./velociraptor" || exit 1
 chmod +x ./velociraptor
@@ -171,12 +83,10 @@ chmod +x ./velociraptor
 # Also fetch the darwin-arm64 binary so we can build a self-contained Apple
 # Silicon collector. Both macOS specs resolve to a single "VelociraptorCollector"
 # tool with no default URL, so each arch's binary must be registered before its
-# build or the collector becomes a tiny BYO-binary shell stub.
-# Pin to the EXACT host version ($velociraptor_version, derived from the
-# darwin-amd64 host binary) via an exact name match rather than a lexicographic
-# sort_by(.name)|last — this picks the right patch and fails loud on per-arch
-# version skew instead of embedding a mismatched, version-bound binary.
-darwin_arm64_url=$(echo "$response" | jq -r --arg n "velociraptor-v${velociraptor_version}-darwin-arm64" '.assets[] | select(.name == $n) | .browser_download_url')
+# build or the collector becomes a tiny BYO-binary shell stub. Pin to the EXACT
+# host version (an exact name match) so per-arch version skew fails loud instead
+# of embedding a mismatched, version-bound binary.
+darwin_arm64_url=$(asset_url_by_name "$response" "velociraptor-v${velociraptor_version}-darwin-arm64")
 if [ -z "$darwin_arm64_url" ] || [ "$darwin_arm64_url" == "null" ]; then
   echo "Error: darwin-arm64 binary for v${velociraptor_version} not found in the latest release (host is darwin-amd64 v${velociraptor_version}; per-arch version skew?)" >&2
   exit 1

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -134,9 +134,21 @@ download_with_retry() {
   return 1
 }
 
-# Download Velociraptor binary and make it executable
+# Download Velociraptor binary and make it executable (darwin-amd64 host binary)
 download_with_retry "$download_url" "./velociraptor" || exit 1
 chmod +x ./velociraptor
+
+# Also fetch the darwin-arm64 binary so we can build a self-contained Apple
+# Silicon collector. Both macOS specs resolve to a single "VelociraptorCollector"
+# tool with no default URL, so each arch's binary must be registered before its
+# build or the collector becomes a tiny BYO-binary shell stub.
+darwin_arm64_url=$(echo "$response" | jq -r '[.assets[] | select(.name | test("darwin-arm64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last | .url')
+if [ -z "$darwin_arm64_url" ] || [ "$darwin_arm64_url" == "null" ]; then
+  echo "Error: Could not find a darwin-arm64 binary in the latest release" >&2
+  exit 1
+fi
+echo "Downloading Velociraptor darwin-arm64 binary..."
+download_with_retry "$darwin_arm64_url" "./velociraptor_darwin_arm64" || exit 1
 
 # Download and extract Windows.Triage.Targets artifact
 mkdir -p ./datastore/artifact_definitions/Windows/Triage
@@ -227,10 +239,29 @@ echo "Building Windows x86 collector..."
 echo "Building Linux collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec_linux.yaml
 
-# Build the macOS x64 collector using the same datastore
-echo "Building macOS x64 collector..."
-./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml
+# Embed the darwin velociraptor binary into each macOS collector. Both specs map
+# to the single "VelociraptorCollector" tool, so register the matching arch's
+# binary into the datastore inventory immediately before each build. "tools
+# upload" works through a server config rather than --datastore, so generate a
+# minimal config pointed at the same ./datastore the collector builds use.
+# (./velociraptor is the darwin-amd64 host binary downloaded above.)
+echo "Generating server config for darwin tool registration..."
+./velociraptor config generate > server.config.yaml
+DATASTORE_ABS="$(pwd)/datastore"
+awk -v ds="$DATASTORE_ABS" '
+  /^Datastore:/ { in_ds = 1 }
+  in_ds && /^  location:/ { print "  location: " ds; next }
+  in_ds && /^  filestore_directory:/ { print "  filestore_directory: " ds; next }
+  /^[A-Za-z]/ && !/^Datastore:/ { in_ds = 0 }
+  { print }
+' server.config.yaml > server.config.yaml.tmp && mv server.config.yaml.tmp server.config.yaml
 
-# Build the macOS ARM64 collector using the same datastore
-echo "Building macOS ARM64 collector..."
+# Build the macOS ARM64 collector (embed darwin-arm64 binary)
+echo "Registering darwin-arm64 binary and building macOS ARM64 collector..."
+./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_arm64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos_arm.yaml
+
+# Build the macOS x64 collector (re-point VelociraptorCollector to darwin-amd64)
+echo "Registering darwin-amd64 binary and building macOS x64 collector..."
+./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor
+./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -55,7 +55,13 @@ if [ -z "$response" ]; then
 fi
 
 # Identify download URL and derive version from asset name
-asset_info=$(echo "$response" | jq -r '[.assets[] | select(.name | test("velociraptor-.*-darwin-amd64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last')
+asset_info=$(echo "$response" | jq -r '
+  [.assets[]
+   | select(.name | test("velociraptor-v[0-9.]+-darwin-amd64$"))
+   | {name: .name,
+      url: .browser_download_url,
+      ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-darwin-amd64$").v | split(".") | map(tonumber))}]
+  | sort_by(.ver) | last')
 download_url=$(echo "$asset_info" | jq -r '.url')
 asset_name=$(echo "$asset_info" | jq -r '.name')
 
@@ -132,6 +138,30 @@ download_with_retry() {
 
   echo "Error: Failed to download binary after $max_retries attempts" >&2
   return 1
+}
+
+# Verify a built collector is a real self-contained binary, not the ~100KB
+# BYO-binary shell stub the offline-collector builder emits when an embedded
+# tool fails to resolve. Checks both size and that the file is a compiled
+# executable (PE/ELF/Mach-O) rather than a shell script / text. Applied to every
+# released collector, not just macOS — any spec can stub out the same way.
+verify_collector_not_stub() {
+  local f="$1"
+  local min_bytes=10000000
+  local size ftype
+  size=$(wc -c < "$f")
+  ftype=$(file -b "$f")
+  if [ "$size" -lt "$min_bytes" ]; then
+    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
+    exit 1
+  fi
+  case "$ftype" in
+    *"shell script"*|*"text"*)
+      echo "Error: $f is '$ftype' — expected a compiled executable, got a script/text (stub?)" >&2
+      exit 1
+      ;;
+  esac
+  echo "Verified self-contained collector: $f ($size bytes, $ftype)"
 }
 
 # Download Velociraptor binary and make it executable (darwin-amd64 host binary)
@@ -234,14 +264,17 @@ echo "Metadata written to data/velociraptor-version.json"
 # Build the Windows x64 collector
 echo "Building Windows x64 collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector.exe
 
 # Build the Windows x86 (32-bit) collector using the same datastore
 echo "Building Windows x86 collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec_x86.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_x86.exe
 
 # Build the Linux collector using the same datastore
 echo "Building Linux collector..."
 ./velociraptor collector --datastore ./datastore/ ./config/spec_linux.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_Linux
 
 # Embed the darwin velociraptor binary into each macOS collector. Both specs map
 # to the single "VelociraptorCollector" tool, so register the matching arch's
@@ -249,21 +282,6 @@ echo "Building Linux collector..."
 # upload" works through a server config rather than --datastore, so generate a
 # minimal config pointed at the same ./datastore the collector builds use.
 # (./velociraptor is the darwin-amd64 host binary downloaded above.)
-# A self-contained macOS collector embeds the ~60-70MB darwin binary. If the
-# tool registration silently fails, the builder falls back to a ~100KB
-# BYO-binary shell stub. Fail the build rather than ship a stub.
-verify_collector_not_stub() {
-  local f="$1"
-  local min_bytes=10000000
-  local size
-  size=$(wc -c < "$f")
-  if [ "$size" -lt "$min_bytes" ]; then
-    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
-    exit 1
-  fi
-  echo "Verified self-contained collector: $f ($size bytes)"
-}
-
 echo "Generating server config for darwin tool registration..."
 ./velociraptor config generate > server.config.yaml
 DATASTORE_ABS="$(pwd)/datastore"

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -142,9 +142,13 @@ chmod +x ./velociraptor
 # Silicon collector. Both macOS specs resolve to a single "VelociraptorCollector"
 # tool with no default URL, so each arch's binary must be registered before its
 # build or the collector becomes a tiny BYO-binary shell stub.
-darwin_arm64_url=$(echo "$response" | jq -r '[.assets[] | select(.name | test("darwin-arm64$")) | {name: .name, url: .browser_download_url}] | sort_by(.name) | last | .url')
+# Pin to the EXACT host version ($velociraptor_version, derived from the
+# darwin-amd64 host binary) via an exact name match rather than a lexicographic
+# sort_by(.name)|last — this picks the right patch and fails loud on per-arch
+# version skew instead of embedding a mismatched, version-bound binary.
+darwin_arm64_url=$(echo "$response" | jq -r --arg n "velociraptor-v${velociraptor_version}-darwin-arm64" '.assets[] | select(.name == $n) | .browser_download_url')
 if [ -z "$darwin_arm64_url" ] || [ "$darwin_arm64_url" == "null" ]; then
-  echo "Error: Could not find a darwin-arm64 binary in the latest release" >&2
+  echo "Error: darwin-arm64 binary for v${velociraptor_version} not found in the latest release (host is darwin-amd64 v${velociraptor_version}; per-arch version skew?)" >&2
   exit 1
 fi
 echo "Downloading Velociraptor darwin-arm64 binary..."
@@ -245,6 +249,21 @@ echo "Building Linux collector..."
 # upload" works through a server config rather than --datastore, so generate a
 # minimal config pointed at the same ./datastore the collector builds use.
 # (./velociraptor is the darwin-amd64 host binary downloaded above.)
+# A self-contained macOS collector embeds the ~60-70MB darwin binary. If the
+# tool registration silently fails, the builder falls back to a ~100KB
+# BYO-binary shell stub. Fail the build rather than ship a stub.
+verify_collector_not_stub() {
+  local f="$1"
+  local min_bytes=10000000
+  local size
+  size=$(wc -c < "$f")
+  if [ "$size" -lt "$min_bytes" ]; then
+    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
+    exit 1
+  fi
+  echo "Verified self-contained collector: $f ($size bytes)"
+}
+
 echo "Generating server config for darwin tool registration..."
 ./velociraptor config generate > server.config.yaml
 DATASTORE_ABS="$(pwd)/datastore"
@@ -256,12 +275,22 @@ awk -v ds="$DATASTORE_ABS" '
   { print }
 ' server.config.yaml > server.config.yaml.tmp && mv server.config.yaml.tmp server.config.yaml
 
+# Confirm the rewrite actually pointed the datastore at ./datastore, otherwise
+# "tools upload" would target the default datastore and the build would silently
+# emit a stub.
+if ! grep -qF "location: ${DATASTORE_ABS}" server.config.yaml; then
+  echo "Error: server.config.yaml Datastore was not repointed to ${DATASTORE_ABS} (velociraptor config format may have changed)" >&2
+  exit 1
+fi
+
 # Build the macOS ARM64 collector (embed darwin-arm64 binary)
 echo "Registering darwin-arm64 binary and building macOS ARM64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_arm64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos_arm.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS_ARM
 
 # Build the macOS x64 collector (re-point VelociraptorCollector to darwin-amd64)
 echo "Registering darwin-amd64 binary and building macOS x64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml
+verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS

--- a/lib/collector_common.sh
+++ b/lib/collector_common.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# collector_common.sh — shared helpers for build_collector.sh,
+# build_collector_macos.sh, and the version check in .github/workflows/ci.yml.
+#
+# Source this file (`. lib/collector_common.sh`); it only DEFINES functions and
+# has no side effects, so it is safe to source under `set -euo pipefail`.
+
+# Fetch a URL, retrying until the response body is valid JSON.
+# Prints the JSON to stdout; returns non-zero after exhausting retries.
+fetch_with_retry() {
+  local url="$1"
+  local max_retries=3 retry_delay=2 attempt=1 response
+  while [ "$attempt" -le "$max_retries" ]; do
+    if [ "$attempt" -gt 1 ]; then
+      echo "Fetching from GitHub API (attempt $attempt/$max_retries)..." >&2
+    fi
+    response=$(curl -s -L "$url" || true)
+    if echo "$response" | jq -e . >/dev/null 2>&1; then
+      echo "$response"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_retries" ]; then
+      echo "Request failed, retrying in ${retry_delay}s..." >&2
+      sleep "$retry_delay"
+      retry_delay=$((retry_delay * 2))  # Exponential backoff
+    fi
+    attempt=$((attempt + 1))
+  done
+  echo "Error: Failed to fetch valid JSON from GitHub API after $max_retries attempts" >&2
+  echo "Debug - Last response received: ${response:0:200}..." >&2
+  return 1
+}
+
+# Download $1 to file $2 with retries; returns non-zero after exhausting retries.
+download_with_retry() {
+  local url="$1" output="$2"
+  local max_retries=3 retry_delay=2 attempt=1
+  while [ "$attempt" -le "$max_retries" ]; do
+    if [ "$attempt" -gt 1 ]; then
+      echo "Downloading binary (attempt $attempt/$max_retries)..." >&2
+    fi
+    if curl -L "$url" -o "$output" --fail --silent --show-error; then
+      echo "Download successful"
+      return 0
+    fi
+    if [ "$attempt" -lt "$max_retries" ]; then
+      echo "Download failed, retrying in ${retry_delay}s..." >&2
+      rm -f "$output"  # Clean up partial download
+      sleep "$retry_delay"
+      retry_delay=$((retry_delay * 2))  # Exponential backoff
+    fi
+    attempt=$((attempt + 1))
+  done
+  echo "Error: Failed to download binary after $max_retries attempts" >&2
+  return 1
+}
+
+# Print the {name,url} JSON object of the highest *numeric*-version Velociraptor
+# release asset matching arch suffix $2 (e.g. "linux-amd64", "darwin-arm64") in
+# the releases JSON $1. Sorting by parsed numeric version (not lexicographically)
+# means v0.76.10 correctly outranks v0.76.5 — the "latest" release contains many
+# patch versions as separate assets. Returns {"name":null,"url":null} if none
+# match, so callers can guard on a null/empty url.
+select_velociraptor_asset() {
+  local json="$1" arch="$2"
+  echo "$json" | jq -c --arg arch "$arch" '
+    [.assets[]
+     | select(.name | test("velociraptor-v[0-9.]+-" + $arch + "$"))
+     | {name: .name,
+        url: .browser_download_url,
+        ver: (.name | capture("velociraptor-v(?<v>[0-9]+(\\.[0-9]+)*)-" + $arch + "$").v
+                    | split(".") | map(tonumber))}]
+    | sort_by(.ver) | last | {name, url}'
+}
+
+# Print the download URL of the asset whose name is exactly $2 in releases JSON
+# $1; empty if absent. Used to pin a binary to one exact, known version.
+asset_url_by_name() {
+  local json="$1" name="$2"
+  echo "$json" | jq -r --arg n "$name" '.assets[] | select(.name == $n) | .browser_download_url'
+}
+
+# Verify a built collector is a real self-contained binary, not the ~100KB
+# BYO-binary shell stub the offline-collector builder emits when an embedded tool
+# fails to resolve. Requires BOTH a sane size (>= 10MB; real collectors embed a
+# 60-85MB velociraptor binary) AND a compiled-executable file type (ELF/Mach-O/
+# PE) — an allowlist, so a stub classified as a script, text, "data", or "empty"
+# is rejected regardless of `file`'s exact wording. Exits 1 on failure.
+verify_collector_not_stub() {
+  local f="$1"
+  local min_bytes=10000000
+  local size ftype
+  size=$(wc -c < "$f")
+  ftype=$(file -b "$f")
+  if [ "$size" -lt "$min_bytes" ]; then
+    echo "Error: $f is $size bytes (< $min_bytes) — looks like a BYO-binary stub, not a self-contained collector" >&2
+    exit 1
+  fi
+  case "$ftype" in
+    *ELF*|*Mach-O*|*PE32*)
+      echo "Verified self-contained collector: $f ($size bytes, $ftype)" ;;
+    *)
+      echo "Error: $f is '$ftype' — expected a compiled ELF/Mach-O/PE executable, not a script/text/data (stub?)" >&2
+      exit 1 ;;
+  esac
+}


### PR DESCRIPTION
## Summary

Makes the macOS triage collectors **self-contained, runnable binaries** instead of the ~97 KB BYO-binary shell stubs that the previous release shipped, and hardens the build pipeline against the class of failure that caused it.

### The macOS stub bug

Velociraptor's offline-collector builder maps both the `MacOS` and `MacOSArm` targets to a single `VelociraptorCollector` tool that has **no default download URL**. With it unset, the builder emits a shell-script launcher that expects the user to supply a darwin velociraptor binary at runtime. The build only ever downloaded the `linux-amd64` velociraptor binary, so the macOS collectors were never self-contained.

**Fix:** download both darwin binaries (pinned to the exact build-host version) and register the matching arch into the datastore inventory via `tools upload` immediately before each macOS build, re-pointing the shared tool between arches.

### Hardening (from code review)

- **Gate every released collector** with `verify_collector_not_stub` (size ≥ 10 MB **and** ELF/Mach-O/PE file-magic) — the stub fallback is a generic builder property, so Windows/Linux are checked too.
- **Numeric version selection** at the source (both build scripts + `ci.yml`) so `v0.76.10` outranks `v0.76.5` (was lexicographic).
- **Pin darwin binaries to the exact host version** so per-arch publish skew fails loud instead of embedding a mismatched, version-bound binary.
- **Verify the awk datastore-repoint actually took** before `tools upload`.
- **Extracted `lib/collector_common.sh`** (sourced by both scripts and `ci.yml`) to remove ~210 lines of duplicated fetch/download/select/verify logic and give the version algorithm a single source of truth.
- `.gitignore` the downloaded binaries, build datastore, generated server config (private keys), and `.DS_Store`.

## Test plan

- [ ] CI build succeeds and produces all 5 collectors
- [ ] `verify_collector_not_stub` passes for all 5 (i.e. none are stubs)
- [ ] After merge: download the published macOS collectors and confirm they are real Mach-O binaries (~60–70 MB), not shell stubs
- [ ] Confirm Windows/Linux collectors are unchanged and still valid

## Notes / follow-ups (not blocking)

- `build_collector_macos.sh` (local-dev script, not used by CI) still lacks the Linux-artifact ETag/SHA integrity checks that `build_collector.sh` has — a **pre-existing** divergence, not introduced here.
- `verify_collector_not_stub` allowlists any compiled type rather than asserting the expected type per target; a per-target assertion would also catch an arch/OS swap.
