### PR TITLE
Tolerate benign CDN ETag mtime wobble in the download race guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,12 @@ jobs:
             echo "EOF"
           } >> $GITHUB_ENV
 
-          # Compare the content-length component of the ETag, not the full value:
-          # triage.velocidex.com's "<mtime>-<len>" ETags have an mtime prefix that
-          # wobbles between CDN nodes for byte-identical content. Matches the
-          # build's download race guard, so a benign wobble does not force a
-          # rebuild + republish for unchanged content.
-          source ./lib/collector_common.sh
-          if [ "$(etag_content_id "$STORED_ETAG")" = "$(etag_content_id "$CURRENT_ETAG")" ]; then
+          # Change-detection compares the FULL ETag on purpose: it errs toward
+          # rebuilding. A benign CDN mtime wobble may trigger a harmless extra
+          # rebuild, but a real (even same-length) artifact change is never
+          # missed. (The build's download race guard is the opposite — it is
+          # mtime-tolerant to avoid failing a good build on a wobble.)
+          if [ "$STORED_ETAG" = "$CURRENT_ETAG" ]; then
             echo "Triage targets unchanged."
             echo "TRIAGE_TARGETS_CHANGED=false" >> $GITHUB_ENV
           else
@@ -177,10 +176,9 @@ jobs:
             echo "EOF"
           } >> $GITHUB_ENV
 
-          # Compare the content-length component of the ETag, not the full value
-          # (see the Windows step) — tolerate the benign CDN mtime wobble.
-          source ./lib/collector_common.sh
-          if [ "$(etag_content_id "$STORED_ETAG")" = "$(etag_content_id "$CURRENT_ETAG")" ]; then
+          # Full-ETag comparison on purpose — errs toward rebuilding so a real
+          # change is never missed (see the Windows step).
+          if [ "$STORED_ETAG" = "$CURRENT_ETAG" ]; then
             echo "Linux triage targets unchanged."
             echo "LINUX_TRIAGE_TARGETS_CHANGED=false" >> $GITHUB_ENV
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,13 @@ jobs:
             echo "EOF"
           } >> $GITHUB_ENV
 
-          if [ "$STORED_ETAG" = "$CURRENT_ETAG" ]; then
+          # Compare the content-length component of the ETag, not the full value:
+          # triage.velocidex.com's "<mtime>-<len>" ETags have an mtime prefix that
+          # wobbles between CDN nodes for byte-identical content. Matches the
+          # build's download race guard, so a benign wobble does not force a
+          # rebuild + republish for unchanged content.
+          source ./lib/collector_common.sh
+          if [ "$(etag_content_id "$STORED_ETAG")" = "$(etag_content_id "$CURRENT_ETAG")" ]; then
             echo "Triage targets unchanged."
             echo "TRIAGE_TARGETS_CHANGED=false" >> $GITHUB_ENV
           else
@@ -171,7 +177,10 @@ jobs:
             echo "EOF"
           } >> $GITHUB_ENV
 
-          if [ "$STORED_ETAG" = "$CURRENT_ETAG" ]; then
+          # Compare the content-length component of the ETag, not the full value
+          # (see the Windows step) — tolerate the benign CDN mtime wobble.
+          source ./lib/collector_common.sh
+          if [ "$(etag_content_id "$STORED_ETAG")" = "$(etag_content_id "$CURRENT_ETAG")" ]; then
             echo "Linux triage targets unchanged."
             echo "LINUX_TRIAGE_TARGETS_CHANGED=false" >> $GITHUB_ENV
           else

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -115,26 +115,9 @@ download_with_retry "$ARTIFACT_URL" "Windows.Triage.Targets.zip" || exit 1
 ARTIFACT_SHA256=$(sha256sum Windows.Triage.Targets.zip | cut -d' ' -f1)
 echo "Windows.Triage.Targets.zip SHA256: $ARTIFACT_SHA256"
 
-# Re-fetch ETag after download to detect race conditions (artifact changed during build)
+# Detect a truncated/raced download against the server's current state.
 if [ -n "${TRIAGE_ETAG:-}" ]; then
-  POST_DOWNLOAD_HEADERS=$(curl -sI --fail --max-time 30 "$ARTIFACT_URL" 2>/dev/null || true)
-  POST_DOWNLOAD_ETAG=$(echo "$POST_DOWNLOAD_HEADERS" | grep -im1 "^etag:" | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
-
-  # Only compare if we successfully retrieved the post-download ETag
-  if [ -z "$POST_DOWNLOAD_ETAG" ]; then
-    echo "Warning: Could not verify ETag after download (HEAD request returned no ETag)" >&2
-    echo "Continuing with SHA256 verification as fallback..." >&2
-  elif [ "$(etag_content_id "$TRIAGE_ETAG")" != "$(etag_content_id "$POST_DOWNLOAD_ETAG")" ]; then
-    echo "Error: Artifact content changed during download (race condition detected)" >&2
-    echo "  Pre-download ETag:  $TRIAGE_ETAG" >&2
-    echo "  Post-download ETag: $POST_DOWNLOAD_ETAG" >&2
-    echo "This indicates the artifact was updated while we were building." >&2
-    echo "Please re-run the build to get the latest version." >&2
-    rm -f Windows.Triage.Targets.zip
-    exit 1
-  else
-    echo "ETag verified: artifact content unchanged during download"
-  fi
+  verify_download_not_raced "$ARTIFACT_URL" "Windows.Triage.Targets.zip" "$TRIAGE_ETAG" "Windows.Triage.Targets"
 fi
 
 # Verify hash against previously stored value (detect tampering if ETag reused)
@@ -170,25 +153,9 @@ download_with_retry "$LINUX_ARTIFACT_URL" "Linux.Triage.UAC.zip" || exit 1
 LINUX_ARTIFACT_SHA256=$(sha256sum Linux.Triage.UAC.zip | cut -d' ' -f1)
 echo "Linux.Triage.UAC.zip SHA256: $LINUX_ARTIFACT_SHA256"
 
-# Re-fetch ETag after download to detect race conditions (artifact changed during build)
+# Detect a truncated/raced download against the server's current state.
 if [ -n "${LINUX_TRIAGE_ETAG:-}" ]; then
-  POST_DOWNLOAD_HEADERS=$(curl -sI --fail --max-time 30 "$LINUX_ARTIFACT_URL" 2>/dev/null || true)
-  POST_DOWNLOAD_ETAG=$(echo "$POST_DOWNLOAD_HEADERS" | grep -im1 "^etag:" | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
-
-  if [ -z "$POST_DOWNLOAD_ETAG" ]; then
-    echo "Warning: Could not verify Linux artifact ETag after download (HEAD request returned no ETag)" >&2
-    echo "Continuing with SHA256 verification as fallback..." >&2
-  elif [ "$(etag_content_id "$LINUX_TRIAGE_ETAG")" != "$(etag_content_id "$POST_DOWNLOAD_ETAG")" ]; then
-    echo "Error: Linux artifact content changed during download (race condition detected)" >&2
-    echo "  Pre-download ETag:  $LINUX_TRIAGE_ETAG" >&2
-    echo "  Post-download ETag: $POST_DOWNLOAD_ETAG" >&2
-    echo "This indicates the artifact was updated while we were building." >&2
-    echo "Please re-run the build to get the latest version." >&2
-    rm -f Linux.Triage.UAC.zip
-    exit 1
-  else
-    echo "Linux artifact ETag verified: artifact content unchanged during download"
-  fi
+  verify_download_not_raced "$LINUX_ARTIFACT_URL" "Linux.Triage.UAC.zip" "$LINUX_TRIAGE_ETAG" "Linux.Triage.UAC"
 fi
 
 # Verify Linux artifact hash against previously stored value (detect tampering if ETag reused)

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -124,8 +124,8 @@ if [ -n "${TRIAGE_ETAG:-}" ]; then
   if [ -z "$POST_DOWNLOAD_ETAG" ]; then
     echo "Warning: Could not verify ETag after download (HEAD request returned no ETag)" >&2
     echo "Continuing with SHA256 verification as fallback..." >&2
-  elif [ "$TRIAGE_ETAG" != "$POST_DOWNLOAD_ETAG" ]; then
-    echo "Error: Artifact ETag changed during download (race condition detected)" >&2
+  elif [ "$(etag_content_id "$TRIAGE_ETAG")" != "$(etag_content_id "$POST_DOWNLOAD_ETAG")" ]; then
+    echo "Error: Artifact content changed during download (race condition detected)" >&2
     echo "  Pre-download ETag:  $TRIAGE_ETAG" >&2
     echo "  Post-download ETag: $POST_DOWNLOAD_ETAG" >&2
     echo "This indicates the artifact was updated while we were building." >&2
@@ -133,7 +133,7 @@ if [ -n "${TRIAGE_ETAG:-}" ]; then
     rm -f Windows.Triage.Targets.zip
     exit 1
   else
-    echo "ETag verified: artifact unchanged during download"
+    echo "ETag verified: artifact content unchanged during download"
   fi
 fi
 
@@ -178,8 +178,8 @@ if [ -n "${LINUX_TRIAGE_ETAG:-}" ]; then
   if [ -z "$POST_DOWNLOAD_ETAG" ]; then
     echo "Warning: Could not verify Linux artifact ETag after download (HEAD request returned no ETag)" >&2
     echo "Continuing with SHA256 verification as fallback..." >&2
-  elif [ "$LINUX_TRIAGE_ETAG" != "$POST_DOWNLOAD_ETAG" ]; then
-    echo "Error: Linux artifact ETag changed during download (race condition detected)" >&2
+  elif [ "$(etag_content_id "$LINUX_TRIAGE_ETAG")" != "$(etag_content_id "$POST_DOWNLOAD_ETAG")" ]; then
+    echo "Error: Linux artifact content changed during download (race condition detected)" >&2
     echo "  Pre-download ETag:  $LINUX_TRIAGE_ETAG" >&2
     echo "  Post-download ETag: $POST_DOWNLOAD_ETAG" >&2
     echo "This indicates the artifact was updated while we were building." >&2
@@ -187,7 +187,7 @@ if [ -n "${LINUX_TRIAGE_ETAG:-}" ]; then
     rm -f Linux.Triage.UAC.zip
     exit 1
   else
-    echo "Linux artifact ETag verified: artifact unchanged during download"
+    echo "Linux artifact ETag verified: artifact content unchanged during download"
   fi
 fi
 

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -115,7 +115,8 @@ download_with_retry "$ARTIFACT_URL" "Windows.Triage.Targets.zip" || exit 1
 ARTIFACT_SHA256=$(sha256sum Windows.Triage.Targets.zip | cut -d' ' -f1)
 echo "Windows.Triage.Targets.zip SHA256: $ARTIFACT_SHA256"
 
-# Detect a truncated/raced download against the server's current state.
+# Detect a mid-build republish (release raced our build); curl already ensured
+# the download itself is complete.
 if [ -n "${TRIAGE_ETAG:-}" ]; then
   verify_download_not_raced "$ARTIFACT_URL" "Windows.Triage.Targets.zip" "$TRIAGE_ETAG" "Windows.Triage.Targets"
 fi
@@ -153,7 +154,8 @@ download_with_retry "$LINUX_ARTIFACT_URL" "Linux.Triage.UAC.zip" || exit 1
 LINUX_ARTIFACT_SHA256=$(sha256sum Linux.Triage.UAC.zip | cut -d' ' -f1)
 echo "Linux.Triage.UAC.zip SHA256: $LINUX_ARTIFACT_SHA256"
 
-# Detect a truncated/raced download against the server's current state.
+# Detect a mid-build republish (release raced our build); curl already ensured
+# the download itself is complete.
 if [ -n "${LINUX_TRIAGE_ETAG:-}" ]; then
   verify_download_not_raced "$LINUX_ARTIFACT_URL" "Linux.Triage.UAC.zip" "$LINUX_TRIAGE_ETAG" "Linux.Triage.UAC"
 fi

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -104,7 +104,8 @@ download_with_retry "$ARTIFACT_URL" "Windows.Triage.Targets.zip" || exit 1
 ARTIFACT_SHA256=$(shasum -a 256 Windows.Triage.Targets.zip | cut -d' ' -f1)
 echo "Windows.Triage.Targets.zip SHA256: $ARTIFACT_SHA256"
 
-# Detect a truncated/raced download against the server's current state.
+# Detect a mid-build republish (release raced our build); curl already ensured
+# the download itself is complete.
 if [ -n "${TRIAGE_ETAG:-}" ]; then
   verify_download_not_raced "$ARTIFACT_URL" "Windows.Triage.Targets.zip" "$TRIAGE_ETAG" "Windows.Triage.Targets"
 fi

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -104,26 +104,9 @@ download_with_retry "$ARTIFACT_URL" "Windows.Triage.Targets.zip" || exit 1
 ARTIFACT_SHA256=$(shasum -a 256 Windows.Triage.Targets.zip | cut -d' ' -f1)
 echo "Windows.Triage.Targets.zip SHA256: $ARTIFACT_SHA256"
 
-# Re-fetch ETag after download to detect race conditions (artifact changed during build)
+# Detect a truncated/raced download against the server's current state.
 if [ -n "${TRIAGE_ETAG:-}" ]; then
-  POST_DOWNLOAD_HEADERS=$(curl -sI --fail --max-time 30 "$ARTIFACT_URL" 2>/dev/null || true)
-  POST_DOWNLOAD_ETAG=$(echo "$POST_DOWNLOAD_HEADERS" | grep -im1 "^etag:" | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
-
-  # Only compare if we successfully retrieved the post-download ETag
-  if [ -z "$POST_DOWNLOAD_ETAG" ]; then
-    echo "Warning: Could not verify ETag after download (HEAD request returned no ETag)" >&2
-    echo "Continuing with SHA256 verification as fallback..." >&2
-  elif [ "$(etag_content_id "$TRIAGE_ETAG")" != "$(etag_content_id "$POST_DOWNLOAD_ETAG")" ]; then
-    echo "Error: Artifact content changed during download (race condition detected)" >&2
-    echo "  Pre-download ETag:  $TRIAGE_ETAG" >&2
-    echo "  Post-download ETag: $POST_DOWNLOAD_ETAG" >&2
-    echo "This indicates the artifact was updated while we were building." >&2
-    echo "Please re-run the build to get the latest version." >&2
-    rm -f Windows.Triage.Targets.zip
-    exit 1
-  else
-    echo "ETag verified: artifact content unchanged during download"
-  fi
+  verify_download_not_raced "$ARTIFACT_URL" "Windows.Triage.Targets.zip" "$TRIAGE_ETAG" "Windows.Triage.Targets"
 fi
 
 # Verify hash against previously stored value (detect tampering if ETag reused)

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -113,8 +113,8 @@ if [ -n "${TRIAGE_ETAG:-}" ]; then
   if [ -z "$POST_DOWNLOAD_ETAG" ]; then
     echo "Warning: Could not verify ETag after download (HEAD request returned no ETag)" >&2
     echo "Continuing with SHA256 verification as fallback..." >&2
-  elif [ "$TRIAGE_ETAG" != "$POST_DOWNLOAD_ETAG" ]; then
-    echo "Error: Artifact ETag changed during download (race condition detected)" >&2
+  elif [ "$(etag_content_id "$TRIAGE_ETAG")" != "$(etag_content_id "$POST_DOWNLOAD_ETAG")" ]; then
+    echo "Error: Artifact content changed during download (race condition detected)" >&2
     echo "  Pre-download ETag:  $TRIAGE_ETAG" >&2
     echo "  Post-download ETag: $POST_DOWNLOAD_ETAG" >&2
     echo "This indicates the artifact was updated while we were building." >&2
@@ -122,7 +122,7 @@ if [ -n "${TRIAGE_ETAG:-}" ]; then
     rm -f Windows.Triage.Targets.zip
     exit 1
   else
-    echo "ETag verified: artifact unchanged during download"
+    echo "ETag verified: artifact content unchanged during download"
   fi
 fi
 

--- a/lib/collector_common.sh
+++ b/lib/collector_common.sh
@@ -96,35 +96,23 @@ etag_content_id() {
   printf '%s' "${rest%%-*}"   # keep the content-length field (up to the next '-')
 }
 
-# Verify a freshly downloaded artifact is consistent with the server's current
-# state: it was not truncated and was not swapped for a different-length object
-# between the pre-download HEAD (whose ETag is $3) and now. Re-HEADs $1 and
-# checks (a) the on-disk byte size equals the server's current Content-Length —
-# ground truth, catching a truncated/partial download — and (b) the ETag
-# content-length field is unchanged vs the pre-download ETag, catching a
-# mid-download swap. A same-length content swap cannot be detected from HTTP
-# metadata alone (the server exposes no content hash); the separate stored-SHA256
-# reuse check is the only content-level guard and is best-effort.
-# Args: <url> <file> <pre_download_etag> <label>. rm's <file> and exits 1 on mismatch.
+# Detect whether an artifact was republished (swapped for different content)
+# between the pre-download HEAD — whose ETag is $3 — and now, i.e. a release
+# raced our build. download_with_retry already guarantees the bytes are complete
+# (curl --fail errors on a short read vs Content-Length and retries), so this
+# only re-reads the ETag and compares its content-length field, which is
+# mtime-wobble tolerant (see etag_content_id). A same-byte-length content swap
+# cannot be detected from HTTP metadata (no server content hash); the separate
+# stored-SHA256 reuse check is the only content-level guard. If the post-download
+# HEAD yields no ETag (transient/redirect), degrade gracefully rather than fail.
+# The trailing `|| true` keeps the no-match grep from aborting under pipefail.
+# Args: <url> <file> <pre_download_etag> <label>. rm's <file> and exits 1 on a race.
 verify_download_not_raced() {
   local url="$1" file="$2" pre_etag="$3" label="$4"
-  local headers post_etag content_length file_size
-  headers=$(curl -sI --fail --max-time 30 "$url" 2>/dev/null || true)
-  post_etag=$(printf '%s\n' "$headers" | grep -im1 '^etag:' | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
-  content_length=$(printf '%s\n' "$headers" | grep -im1 '^content-length:' | tr -d '\r' | sed 's/^[Cc]ontent-[Ll]ength: *//')
-  file_size=$(wc -c < "$file" | tr -d '[:space:]')
-
-  # (a) Ground-truth size check: on-disk bytes vs the server's advertised length.
-  if [ -n "$content_length" ] && [ "$file_size" != "$content_length" ]; then
-    echo "Error: $label downloaded $file_size bytes but server now reports Content-Length $content_length (truncated or changed mid-download)" >&2
-    echo "Please re-run the build to get a consistent copy." >&2
-    rm -f "$file"
-    exit 1
-  fi
-
-  # (b) Race check: content-length component of the ETag, pre vs post download.
+  local post_etag
+  post_etag=$(curl -sI --fail --max-time 30 "$url" 2>/dev/null | grep -im1 '^etag:' | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//' || true)
   if [ -z "$post_etag" ]; then
-    echo "Warning: could not re-fetch $label ETag after download; relied on size/SHA256 checks" >&2
+    echo "Warning: could not re-fetch $label ETag after download; relying on the completed download + SHA256 checks" >&2
     return 0
   fi
   if [ "$(etag_content_id "$pre_etag")" != "$(etag_content_id "$post_etag")" ]; then
@@ -135,7 +123,7 @@ verify_download_not_raced() {
     rm -f "$file"
     exit 1
   fi
-  echo "$label download verified: $file_size bytes, content unchanged during download"
+  echo "$label download verified: content unchanged during download"
 }
 
 # Verify a built collector is a real self-contained binary, not the ~100KB

--- a/lib/collector_common.sh
+++ b/lib/collector_common.sh
@@ -80,6 +80,21 @@ asset_url_by_name() {
   echo "$json" | jq -r --arg n "$name" '.assets[] | select(.name == $n) | .browser_download_url'
 }
 
+# Extract the content-identifying part of an nginx/S3-style ETag. These servers
+# emit ETags of the form "<mtime-hex>-<content-length-hex>"; the mtime prefix can
+# differ between CDN edge nodes (or after a no-op touch) for byte-identical
+# content, which would otherwise trip the download race-condition guard with a
+# false positive. Comparing only the content-length field tolerates that wobble
+# while still catching a real size-changing swap mid-download (and the stored
+# SHA256 check still guards same-length tampering). Strips a weak-validator W/
+# prefix and quotes; with no '-' it returns the whole de-quoted value so a
+# non-standard ETag still compares exactly.
+etag_content_id() {
+  local etag="${1#W/}"
+  etag="${etag//\"/}"
+  printf '%s' "${etag##*-}"
+}
+
 # Verify a built collector is a real self-contained binary, not the ~100KB
 # BYO-binary shell stub the offline-collector builder emits when an embedded tool
 # fails to resolve. Requires BOTH a sane size (>= 10MB; real collectors embed a

--- a/lib/collector_common.sh
+++ b/lib/collector_common.sh
@@ -101,10 +101,12 @@ etag_content_id() {
 # raced our build. download_with_retry already guarantees the bytes are complete
 # (curl --fail errors on a short read vs Content-Length and retries), so this
 # only re-reads the ETag and compares its content-length field, which is
-# mtime-wobble tolerant (see etag_content_id). A same-byte-length content swap
-# cannot be detected from HTTP metadata (no server content hash); the separate
-# stored-SHA256 reuse check is the only content-level guard. If the post-download
-# HEAD yields no ETag (transient/redirect), degrade gracefully rather than fail.
+# mtime-wobble tolerant (see etag_content_id). This is best-effort: a republish
+# that keeps the exact byte length is not detectable from HTTP metadata (no
+# server content hash), and the stored-SHA256 check elsewhere only fires when the
+# ETag is unchanged across builds, so it does not backstop a mid-build republish
+# either. If the post-download HEAD yields no ETag (transient/redirect), degrade
+# gracefully rather than fail.
 # The trailing `|| true` keeps the no-match grep from aborting under pipefail.
 # Args: <url> <file> <pre_download_etag> <label>. rm's <file> and exits 1 on a race.
 verify_download_not_raced() {

--- a/lib/collector_common.sh
+++ b/lib/collector_common.sh
@@ -81,18 +81,61 @@ asset_url_by_name() {
 }
 
 # Extract the content-identifying part of an nginx/S3-style ETag. These servers
-# emit ETags of the form "<mtime-hex>-<content-length-hex>"; the mtime prefix can
-# differ between CDN edge nodes (or after a no-op touch) for byte-identical
-# content, which would otherwise trip the download race-condition guard with a
-# false positive. Comparing only the content-length field tolerates that wobble
-# while still catching a real size-changing swap mid-download (and the stored
-# SHA256 check still guards same-length tampering). Strips a weak-validator W/
-# prefix and quotes; with no '-' it returns the whole de-quoted value so a
-# non-standard ETag still compares exactly.
+# emit ETags of the form "<mtime-hex>-<content-length-hex>" (optionally with a
+# content-coding suffix like "-gzip"); the mtime prefix can differ between CDN
+# edge nodes (or after a no-op touch) for byte-identical content, which would
+# otherwise trip change-detection and the download race-guard with a false
+# positive. We return the content-length field — the SECOND hyphen-delimited
+# field — so a trailing "-gzip" (or any extra suffix) does not shift which field
+# is read. With no hyphen the whole de-quoted value is returned so a non-standard
+# ETag still compares exactly.
 etag_content_id() {
-  local etag="${1#W/}"
-  etag="${etag//\"/}"
-  printf '%s' "${etag##*-}"
+  local etag="${1#W/}"   # drop weak-validator prefix
+  etag="${etag//\"/}"    # drop quotes
+  local rest="${etag#*-}"     # strip the mtime field (everything up to first '-')
+  printf '%s' "${rest%%-*}"   # keep the content-length field (up to the next '-')
+}
+
+# Verify a freshly downloaded artifact is consistent with the server's current
+# state: it was not truncated and was not swapped for a different-length object
+# between the pre-download HEAD (whose ETag is $3) and now. Re-HEADs $1 and
+# checks (a) the on-disk byte size equals the server's current Content-Length —
+# ground truth, catching a truncated/partial download — and (b) the ETag
+# content-length field is unchanged vs the pre-download ETag, catching a
+# mid-download swap. A same-length content swap cannot be detected from HTTP
+# metadata alone (the server exposes no content hash); the separate stored-SHA256
+# reuse check is the only content-level guard and is best-effort.
+# Args: <url> <file> <pre_download_etag> <label>. rm's <file> and exits 1 on mismatch.
+verify_download_not_raced() {
+  local url="$1" file="$2" pre_etag="$3" label="$4"
+  local headers post_etag content_length file_size
+  headers=$(curl -sI --fail --max-time 30 "$url" 2>/dev/null || true)
+  post_etag=$(printf '%s\n' "$headers" | grep -im1 '^etag:' | tr -d '\r' | sed 's/^[Ee][Tt][Aa][Gg]: *//')
+  content_length=$(printf '%s\n' "$headers" | grep -im1 '^content-length:' | tr -d '\r' | sed 's/^[Cc]ontent-[Ll]ength: *//')
+  file_size=$(wc -c < "$file" | tr -d '[:space:]')
+
+  # (a) Ground-truth size check: on-disk bytes vs the server's advertised length.
+  if [ -n "$content_length" ] && [ "$file_size" != "$content_length" ]; then
+    echo "Error: $label downloaded $file_size bytes but server now reports Content-Length $content_length (truncated or changed mid-download)" >&2
+    echo "Please re-run the build to get a consistent copy." >&2
+    rm -f "$file"
+    exit 1
+  fi
+
+  # (b) Race check: content-length component of the ETag, pre vs post download.
+  if [ -z "$post_etag" ]; then
+    echo "Warning: could not re-fetch $label ETag after download; relied on size/SHA256 checks" >&2
+    return 0
+  fi
+  if [ "$(etag_content_id "$pre_etag")" != "$(etag_content_id "$post_etag")" ]; then
+    echo "Error: $label content changed during download (race condition detected)" >&2
+    echo "  Pre-download ETag:  $pre_etag" >&2
+    echo "  Post-download ETag: $post_etag" >&2
+    echo "Please re-run the build to get the latest version." >&2
+    rm -f "$file"
+    exit 1
+  fi
+  echo "$label download verified: $file_size bytes, content unchanged during download"
 }
 
 # Verify a built collector is a real self-contained binary, not the ~100KB


### PR DESCRIPTION
## Summary

Makes the artifact-download **race guard tolerant of benign CDN ETag wobble**, which twice forced a release re-run this cycle, and refactors the shared logic.

### The flake

triage.velocidex.com serves nginx/S3-style ETags of the form `"<mtime-hex>-<content-length-hex>"`. The mtime prefix differs between CDN edge nodes for byte-identical content (observed: `"69f0d212-ac54"` vs `"69f0d211-ac54"` — same `ac54` length, only the mtime ticked). The download race guard compared the *full* ETag, so a benign wobble between the pre-download HEAD and the post-download HEAD failed the build with "artifact changed during download," requiring a manual re-run.

### Changes

- **`etag_content_id`** (new lib helper): compares the content-length field (the second hyphen-delimited field, so a trailing `-gzip` doesn't shift parsing; non-standard ETags fall back to exact compare).
- **`verify_download_not_raced`** (new lib helper): re-reads the ETag after download and compares the content-length field (mtime-tolerant). Replaces three duplicated inline guard blocks in the build scripts. `curl --fail` in `download_with_retry` already guarantees the bytes are complete, so this is purely a mid-build republish (race) check. Degrades gracefully (warn + continue) if the post-download HEAD returns no ETag, and is pipefail-safe.
- **ci.yml change-detection is intentionally left on the FULL ETag** — it errs toward *rebuilding* (a harmless extra rebuild on a wobble beats silently shipping a stale artifact), the opposite bias from the race guard (which errs toward not failing a good build). Both sites document the asymmetry.

### Validation

- `bash -n` clean on all three scripts; ci.yml is valid YAML.
- `etag_content_id` verified across standard / `-gzip` / weak `W/` / no-hyphen ETags.
- `verify_download_not_raced` verified live: happy path passes, a content-length mismatch exits 1, and a no-ETag HEAD degrades gracefully (return 0) under `set -euo pipefail`.
- Reviewed to a clean bill across multiple passes (the pipefail-abort and a change-detection over-correction were caught and fixed during review).

The PR `build` job exercises `verify_download_not_raced` end-to-end on Ubuntu (it runs when `TRIAGE_ETAG` is set, which the `pull_request` path does).

## Follow-up (pre-existing, not in scope)

`build_collector_macos.sh` (local-dev only, not used by CI) still lacks the race/SHA integrity guard on its Linux-artifact download that `build_collector.sh` has. Pre-existing asymmetry, not introduced or worsened here.
