### PR TITLE
Ad-hoc sign macOS collectors (run on modern macOS) + OS-tabbed instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ CLAUDE.md
 /velociraptor
 /velociraptor_darwin_amd64
 /velociraptor_darwin_arm64
+/rcodesign
+/apple-codesign-*/
+/apple-codesign-*.tar.gz
 /server.config.yaml
 /server.config.yaml.tmp
 /datastore/

--- a/build_collector.sh
+++ b/build_collector.sh
@@ -105,6 +105,26 @@ download_with_retry "$darwin_amd64_url" "./velociraptor_darwin_amd64" || exit 1
 echo "Downloading Velociraptor darwin-arm64 binary..."
 download_with_retry "$darwin_arm64_url" "./velociraptor_darwin_arm64" || exit 1
 
+# Download rcodesign to ad-hoc sign the macOS collectors on this Linux host.
+# Velociraptor's repack appends the embedded config to the darwin binary, which
+# invalidates its code signature; modern macOS then SIGKILLs the collector on
+# launch unless it carries a valid signature. rcodesign signs Mach-O binaries
+# cross-platform. Pinned + SHA256-verified for supply-chain integrity.
+RCODESIGN_VERSION="0.29.0"
+RCODESIGN_TARBALL="apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+RCODESIGN_URL="https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${RCODESIGN_TARBALL}"
+RCODESIGN_SHA256="dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002"
+echo "Downloading rcodesign ${RCODESIGN_VERSION} (macOS collector signer)..."
+download_with_retry "$RCODESIGN_URL" "$RCODESIGN_TARBALL" || exit 1
+echo "${RCODESIGN_SHA256}  ${RCODESIGN_TARBALL}" | sha256sum -c - || {
+  echo "Error: rcodesign tarball SHA256 mismatch — refusing to use it" >&2
+  exit 1
+}
+tar xzf "$RCODESIGN_TARBALL" "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign"
+mv "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl/rcodesign" ./rcodesign
+chmod +x ./rcodesign
+rm -rf "$RCODESIGN_TARBALL" "apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl"
+
 # Download and extract Windows.Triage.Targets artifact
 mkdir -p ./datastore/artifact_definitions/Windows/Triage
 ARTIFACT_URL="https://triage.velocidex.com/artifacts/Windows.Triage.Targets.zip"
@@ -264,14 +284,17 @@ if ! grep -qF "location: ${DATASTORE_ABS}" server.config.yaml; then
   exit 1
 fi
 
-# Build the macOS ARM64 collector (embed darwin-arm64 binary)
+# Build the macOS ARM64 collector (embed darwin-arm64 binary), then ad-hoc sign
+# it so the embedded-config append doesn't leave it unrunnable on modern macOS.
 echo "Registering darwin-arm64 binary and building macOS ARM64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_arm64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos_arm.yaml
+adhoc_sign_macos ./datastore/Velociraptor_Triage_Collector_macOS_ARM || exit 1
 verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS_ARM
 
 # Build the macOS x64 collector (re-point VelociraptorCollector to darwin-amd64)
 echo "Registering darwin-amd64 binary and building macOS x64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_amd64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml
+adhoc_sign_macos ./datastore/Velociraptor_Triage_Collector_macOS || exit 1
 verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS

--- a/build_collector_macos.sh
+++ b/build_collector_macos.sh
@@ -199,10 +199,12 @@ fi
 echo "Registering darwin-arm64 binary and building macOS ARM64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor_darwin_arm64
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos_arm.yaml
+adhoc_sign_macos ./datastore/Velociraptor_Triage_Collector_macOS_ARM || exit 1
 verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS_ARM
 
 # Build the macOS x64 collector (re-point VelociraptorCollector to darwin-amd64)
 echo "Registering darwin-amd64 binary and building macOS x64 collector..."
 ./velociraptor --config server.config.yaml tools upload --name VelociraptorCollector --download ./velociraptor
 ./velociraptor collector --datastore ./datastore/ ./config/spec_macos.yaml
+adhoc_sign_macos ./datastore/Velociraptor_Triage_Collector_macOS || exit 1
 verify_collector_not_stub ./datastore/Velociraptor_Triage_Collector_macOS

--- a/css/styles.css
+++ b/css/styles.css
@@ -327,6 +327,7 @@ body {
 .cards-container {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
     gap: 1.5rem;
     margin: 3rem 0 2rem;
 }
@@ -429,7 +430,10 @@ body {
 
 #tab-windows:checked ~ #panel-windows,
 #tab-linux:checked ~ #panel-linux,
-#tab-macos:checked ~ #panel-macos {
+#tab-macos:checked ~ #panel-macos,
+#howto-windows:checked ~ #howto-panel-windows,
+#howto-linux:checked ~ #howto-panel-linux,
+#howto-macos:checked ~ #howto-panel-macos {
     display: block;
 }
 
@@ -490,6 +494,33 @@ body {
 .slim-tip {
     padding: 0.7rem 0.9rem;
     font-size: 0.9rem;
+}
+
+.instructions p code {
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    color: #cfe9ee;
+    background: rgba(79, 244, 255, 0.08);
+    padding: 0.05rem 0.35rem;
+    border-radius: 5px;
+    word-break: break-word;
+}
+
+.cmd {
+    display: block;
+    margin-top: 0.7rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 10px;
+    background: rgba(2, 6, 16, 0.55);
+    border: 1px solid rgba(79, 244, 255, 0.18);
+    color: #cfe9ee;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+    user-select: all;
 }
 
 .features {

--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
                             </div>
                         </li>
                     </ol>
+                    <div class="tip slim-tip"><i class="fa-brands fa-apple" aria-hidden="true"></i> <strong>macOS:</strong> downloaded collectors are quarantined by Gatekeeper and may report &ldquo;damaged.&rdquo; Clear the quarantine flag, then run with <code>sudo</code>:<br><code>xattr -d com.apple.quarantine Velociraptor_Triage_Collector_macOS_ARM</code></div>
                     <div class="tip">Need timelines? Convert the triage archive into full forensic timelines using our <a href="https://github.com/Digital-Defense-Institute/openrelik-pipeline" target="_blank" rel="noreferrer noopener">openrelik-pipeline</a>.</div>
                 </div>
             </section>

--- a/index.html
+++ b/index.html
@@ -134,30 +134,100 @@
 
                 <div class="card instructions">
                     <h2>How to Use the Collector</h2>
-                    <ol class="steps">
-                        <li>
-                            <span class="step-label">1</span>
-                            <div>
-                                <strong>Download</strong>
-                                <p>Grab the latest release for your platform and place it on the target host.</p>
-                            </div>
-                        </li>
-                        <li>
-                            <span class="step-label">2</span>
-                            <div>
-                                <strong>Collect</strong>
-                                <p>Run the collector with elevated privileges (admin/root) and let it finish.</p>
-                            </div>
-                        </li>
-                        <li>
-                            <span class="step-label">3</span>
-                            <div>
-                                <strong>Extract</strong>
-                                <p>Retrieve the generated ZIP archive for immediate analysis.</p>
-                            </div>
-                        </li>
-                    </ol>
-                    <div class="tip slim-tip"><i class="fa-brands fa-apple" aria-hidden="true"></i> <strong>macOS:</strong> downloaded collectors are quarantined by Gatekeeper and may report &ldquo;damaged.&rdquo; Clear the quarantine flag, then run with <code>sudo</code>:<br><code>xattr -d com.apple.quarantine Velociraptor_Triage_Collector_macOS_ARM</code></div>
+
+                    <div class="artifact-tabs">
+                        <input type="radio" name="howto-tab" id="howto-windows" checked>
+                        <label for="howto-windows"><i class="fa-brands fa-windows" aria-hidden="true"></i> Windows</label>
+
+                        <input type="radio" name="howto-tab" id="howto-linux">
+                        <label for="howto-linux"><i class="fa-brands fa-linux" aria-hidden="true"></i> Linux</label>
+
+                        <input type="radio" name="howto-tab" id="howto-macos">
+                        <label for="howto-macos"><i class="fa-brands fa-apple" aria-hidden="true"></i> macOS</label>
+
+                        <div class="tab-panel" id="howto-panel-windows">
+                            <ol class="steps">
+                                <li>
+                                    <span class="step-label">1</span>
+                                    <div>
+                                        <strong>Download</strong>
+                                        <p>Grab <code>Velociraptor_Triage_Collector.exe</code> (or the x86 build for 32-bit hosts) and copy it to the target.</p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="step-label">2</span>
+                                    <div>
+                                        <strong>Run as Administrator</strong>
+                                        <p>Right-click &rarr; <em>Run as administrator</em>, or launch it from an elevated PowerShell / Command Prompt, and let it finish.</p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="step-label">3</span>
+                                    <div>
+                                        <strong>Collect the archive</strong>
+                                        <p>Retrieve the generated <code>Triage-&lt;host&gt;-&lt;timestamp&gt;.zip</code> for analysis.</p>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+
+                        <div class="tab-panel" id="howto-panel-linux">
+                            <ol class="steps">
+                                <li>
+                                    <span class="step-label">1</span>
+                                    <div>
+                                        <strong>Download</strong>
+                                        <p>Grab <code>Velociraptor_Triage_Collector_Linux</code> and copy it to the target host.</p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="step-label">2</span>
+                                    <div>
+                                        <strong>Make executable &amp; run</strong>
+                                        <p>Mark it executable and run it with <code>sudo</code>:</p>
+                                        <code class="cmd">chmod +x Velociraptor_Triage_Collector_Linux
+sudo ./Velociraptor_Triage_Collector_Linux</code>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="step-label">3</span>
+                                    <div>
+                                        <strong>Collect the archive</strong>
+                                        <p>Retrieve the generated <code>Triage-&lt;host&gt;-&lt;timestamp&gt;.zip</code> for analysis.</p>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+
+                        <div class="tab-panel" id="howto-panel-macos">
+                            <ol class="steps">
+                                <li>
+                                    <span class="step-label">1</span>
+                                    <div>
+                                        <strong>Download</strong>
+                                        <p>Grab <code>Velociraptor_Triage_Collector_macOS</code> (Intel) or <code>Velociraptor_Triage_Collector_macOS_ARM</code> (Apple Silicon).</p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="step-label">2</span>
+                                    <div>
+                                        <strong>Clear quarantine &amp; run</strong>
+                                        <p>Browser downloads are quarantined by Gatekeeper and may report &ldquo;damaged.&rdquo; Clear the flag, then run with <code>sudo</code>:</p>
+                                        <code class="cmd">xattr -d com.apple.quarantine Velociraptor_Triage_Collector_macOS_ARM
+sudo ./Velociraptor_Triage_Collector_macOS_ARM</code>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="step-label">3</span>
+                                    <div>
+                                        <strong>Collect the archive</strong>
+                                        <p>Retrieve the generated <code>Triage-&lt;host&gt;-&lt;timestamp&gt;.zip</code> for analysis.</p>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+
                     <div class="tip">Need timelines? Convert the triage archive into full forensic timelines using our <a href="https://github.com/Digital-Defense-Institute/openrelik-pipeline" target="_blank" rel="noreferrer noopener">openrelik-pipeline</a>.</div>
                 </div>
             </section>

--- a/lib/collector_common.sh
+++ b/lib/collector_common.sh
@@ -152,3 +152,28 @@ verify_collector_not_stub() {
       exit 1 ;;
   esac
 }
+
+# Ad-hoc code-sign a macOS (Mach-O) collector so modern macOS will run it.
+# Velociraptor's offline-collector builder embeds the collection config by
+# APPENDING it to the darwin velociraptor binary, which invalidates the binary's
+# code signature. macOS (Sequoia / 26+) then SIGKILLs the collector on launch
+# ("zsh: killed"). An ad-hoc signature (no certificate) restores a valid
+# signature so it runs. NOTE: ad-hoc is NOT notarization — a browser download is
+# still Gatekeeper-quarantined and needs `xattr -d com.apple.quarantine` first.
+# Prefers Apple's codesign (macOS host); on Linux CI uses rcodesign, which can
+# sign Mach-O cross-platform (`./rcodesign` if downloaded into the workspace, or
+# on PATH). Signing is required: returns non-zero if no signer is available.
+adhoc_sign_macos() {
+  local file="$1"
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$file" || return 1
+  elif [ -x ./rcodesign ]; then
+    ./rcodesign sign "$file" || return 1
+  elif command -v rcodesign >/dev/null 2>&1; then
+    rcodesign sign "$file" || return 1
+  else
+    echo "Error: no ad-hoc signing tool (codesign or rcodesign) found to sign $file" >&2
+    return 1
+  fi
+  echo "Ad-hoc signed: $file"
+}


### PR DESCRIPTION
## Summary

Two related macOS fixes plus a landing-page revamp.

### 1. macOS collectors are now runnable out of the box (CI ad-hoc signing)

Velociraptor's offline-collector builder embeds the collection config by **appending it to the darwin velociraptor binary, which invalidates the binary's code signature.** On macOS Sequoia / 26+ the OS then **SIGKILLs the collector on launch** (`zsh: killed`) — so the shipped macOS collectors were effectively unrunnable.

- New `lib/collector_common.sh` helper `adhoc_sign_macos`: uses Apple's `codesign` on a macOS host, else **`rcodesign`** (which signs Mach-O cross-platform) on the Linux CI runner. Signing is required — the build fails if no signer is available.
- `build_collector.sh` downloads `rcodesign` 0.29.0 (**pinned + SHA256-verified**) and signs both macOS collectors after build / before the stub check (so the released artifact is the signed one). `build_collector_macos.sh` signs via the same helper using native `codesign`.

Verified locally: both `rcodesign` and `codesign` produce signatures Apple's `codesign --verify` accepts, and the resulting collector runs.

> Ad-hoc signing is **not** notarization, so a browser-downloaded collector is still Gatekeeper-quarantined ("damaged") and needs `xattr -d com.apple.quarantine …` once. Per the project decision, notarization is out of scope.

### 2. Landing page: OS-tabbed "How to Use the Collector"

Converted the static 3 steps into **Windows / Linux / macOS tabs** (mirroring the "What This Collector Gathers" card) with tailored steps per platform — including the macOS quarantine-strip command in a styled command block. Also top-aligned the cards grid so the shorter card no longer stretches to match the taller one.

## Test plan

- [ ] CI `build` job signs both macOS collectors and they pass `verify_collector_not_stub`
- [ ] After merge: download a macOS collector, `xattr -d com.apple.quarantine …`, and confirm it runs (no SIGKILL)
- [ ] Landing page: click through the new OS tabs; commands render cleanly

## Related

Supersedes the workaround in issue #17's discussion; the local-only `build_collector_macos.sh` Linux-artifact integrity gap (issue #17) remains separate and out of scope.
